### PR TITLE
소셜 로그인 2단계 플로우 구현

### DIFF
--- a/src/main/java/com/littlehikerfriends/config/JwtUtil.java
+++ b/src/main/java/com/littlehikerfriends/config/JwtUtil.java
@@ -85,4 +85,49 @@ public class JwtUtil {
     private SecretKey getSigningKey() {
         return Keys.hmacShaKeyFor(secret.getBytes());
     }
+    
+    /**
+     * 임시 토큰 생성 (프로필 생성용, 10분 유효)
+     */
+    public String generateTempToken(String email, String provider) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + 1800000); // 30분
+        
+        return Jwts.builder()
+                .setSubject(email)
+                .claim("provider", provider)
+                .claim("type", "temp")
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(getSigningKey())
+                .compact();
+    }
+    
+    /**
+     * 임시 토큰 검증
+     */
+    public boolean validateTempToken(String token) {
+        try {
+            Claims claims = getClaimsFromToken(token);
+            return "temp".equals(claims.get("type"));
+        } catch (Exception e) {
+            return false;
+        }
+    }
+    
+    /**
+     * 임시 토큰에서 이메일 추출
+     */
+    public String getEmailFromTempToken(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return claims.getSubject();
+    }
+    
+    /**
+     * 임시 토큰에서 Provider 추출
+     */
+    public String getProviderFromTempToken(String token) {
+        Claims claims = getClaimsFromToken(token);
+        return claims.get("provider", String.class);
+    }
 }

--- a/src/main/java/com/littlehikerfriends/dto/ProfileCreateRequest.java
+++ b/src/main/java/com/littlehikerfriends/dto/ProfileCreateRequest.java
@@ -1,0 +1,43 @@
+package com.littlehikerfriends.dto;
+
+import com.littlehikerfriends.entity.Provider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class ProfileCreateRequest {
+    
+    @NotNull(message = "로그인 제공자는 필수입니다")
+    private Provider provider;
+    
+    @NotBlank(message = "소셜 로그인 토큰은 필수입니다")
+    private String socialToken;
+    
+    @NotBlank(message = "닉네임은 필수입니다")
+    private String nickname;
+    
+    private String imageUrl; // 프로필 이미지 (선택사항)
+    
+    // 기본 생성자
+    public ProfileCreateRequest() {}
+    
+    // 생성자
+    public ProfileCreateRequest(Provider provider, String socialToken, String nickname, String imageUrl) {
+        this.provider = provider;
+        this.socialToken = socialToken;
+        this.nickname = nickname;
+        this.imageUrl = imageUrl;
+    }
+    
+    // Getters and Setters
+    public Provider getProvider() { return provider; }
+    public void setProvider(Provider provider) { this.provider = provider; }
+    
+    public String getSocialToken() { return socialToken; }
+    public void setSocialToken(String socialToken) { this.socialToken = socialToken; }
+    
+    public String getNickname() { return nickname; }
+    public void setNickname(String nickname) { this.nickname = nickname; }
+    
+    public String getImageUrl() { return imageUrl; }
+    public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+}

--- a/src/main/java/com/littlehikerfriends/dto/SocialLoginCheckRequest.java
+++ b/src/main/java/com/littlehikerfriends/dto/SocialLoginCheckRequest.java
@@ -1,0 +1,30 @@
+package com.littlehikerfriends.dto;
+
+import com.littlehikerfriends.entity.Provider;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public class SocialLoginCheckRequest {
+    
+    @NotNull(message = "로그인 제공자는 필수입니다")
+    private Provider provider;
+    
+    @NotBlank(message = "소셜 로그인 토큰은 필수입니다")
+    private String socialToken;
+    
+    // 기본 생성자
+    public SocialLoginCheckRequest() {}
+    
+    // 생성자
+    public SocialLoginCheckRequest(Provider provider, String socialToken) {
+        this.provider = provider;
+        this.socialToken = socialToken;
+    }
+    
+    // Getters and Setters
+    public Provider getProvider() { return provider; }
+    public void setProvider(Provider provider) { this.provider = provider; }
+    
+    public String getSocialToken() { return socialToken; }
+    public void setSocialToken(String socialToken) { this.socialToken = socialToken; }
+}

--- a/src/main/java/com/littlehikerfriends/dto/SocialLoginCheckResponse.java
+++ b/src/main/java/com/littlehikerfriends/dto/SocialLoginCheckResponse.java
@@ -1,0 +1,34 @@
+package com.littlehikerfriends.dto;
+
+public class SocialLoginCheckResponse {
+    
+    private boolean isExistingUser;
+    private String email;
+    private LoginResponse loginResponse; // 기존 사용자용 로그인 정보
+    
+    // 기본 생성자
+    public SocialLoginCheckResponse() {}
+    
+    // 기존 사용자용 생성자
+    public SocialLoginCheckResponse(boolean isExistingUser, String email, LoginResponse loginResponse) {
+        this.isExistingUser = isExistingUser;
+        this.email = email;
+        this.loginResponse = loginResponse;
+    }
+    
+    // 신규 사용자용 생성자
+    public SocialLoginCheckResponse(boolean isExistingUser, String email) {
+        this.isExistingUser = isExistingUser;
+        this.email = email;
+    }
+    
+    // Getters and Setters
+    public boolean isExistingUser() { return isExistingUser; }
+    public void setExistingUser(boolean existingUser) { isExistingUser = existingUser; }
+    
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    
+    public LoginResponse getLoginResponse() { return loginResponse; }
+    public void setLoginResponse(LoginResponse loginResponse) { this.loginResponse = loginResponse; }
+}

--- a/src/main/java/com/littlehikerfriends/service/SocialAuthService.java
+++ b/src/main/java/com/littlehikerfriends/service/SocialAuthService.java
@@ -1,0 +1,94 @@
+package com.littlehikerfriends.service;
+
+import com.littlehikerfriends.entity.Provider;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Service
+public class SocialAuthService {
+    
+    private final RestTemplate restTemplate = new RestTemplate();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    
+    /**
+     * 소셜 토큰으로 사용자 이메일 조회
+     */
+    public String getEmailFromSocialToken(Provider provider, String socialToken) {
+        switch (provider) {
+            case KAKAO:
+                return getKakaoEmail(socialToken);
+            case GOOGLE:
+                return getGoogleEmail(socialToken);
+            case APPLE:
+                return getAppleEmail(socialToken);
+            default:
+                throw new RuntimeException("지원하지 않는 소셜 로그인 제공자입니다: " + provider);
+        }
+    }
+    
+    /**
+     * 카카오 API로 이메일 조회
+     */
+    private String getKakaoEmail(String accessToken) {
+        try {
+            String url = "https://kapi.kakao.com/v2/user/me";
+            
+            HttpHeaders headers = new HttpHeaders();
+            headers.set("Authorization", "Bearer " + accessToken);
+            
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+            ResponseEntity<String> response = restTemplate.exchange(url, HttpMethod.GET, entity, String.class);
+            
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+            return jsonNode.path("kakao_account").path("email").asText();
+            
+        } catch (Exception e) {
+            throw new RuntimeException("카카오 토큰 검증 실패: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * 구글 API로 이메일 조회
+     */
+    private String getGoogleEmail(String accessToken) {
+        try {
+            String url = "https://www.googleapis.com/oauth2/v2/userinfo?access_token=" + accessToken;
+            
+            ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+            
+            JsonNode jsonNode = objectMapper.readTree(response.getBody());
+            return jsonNode.path("email").asText();
+            
+        } catch (Exception e) {
+            throw new RuntimeException("구글 토큰 검증 실패: " + e.getMessage());
+        }
+    }
+    
+    /**
+     * 애플 API로 이메일 조회 (JWT 토큰 디코딩)
+     */
+    private String getAppleEmail(String idToken) {
+        try {
+            // Apple ID Token은 JWT 형태이므로 디코딩 필요
+            // 실제 구현시에는 Apple의 공개키로 서명 검증도 해야 함
+            String[] chunks = idToken.split("\\.");
+            if (chunks.length != 3) {
+                throw new RuntimeException("잘못된 Apple ID Token 형식");
+            }
+            
+            String payload = new String(java.util.Base64.getUrlDecoder().decode(chunks[1]));
+            JsonNode jsonNode = objectMapper.readTree(payload);
+            
+            return jsonNode.path("email").asText();
+            
+        } catch (Exception e) {
+            throw new RuntimeException("애플 토큰 검증 실패: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
주요 변경사항:
• 소셜 로그인을 2단계로 분리 (체크 → 프로필 생성)
• 임시토큰 제거하고 소셜 토큰 직접 사용
• 이메일/소셜 회원가입 API 명확히 구분

새로운 API:
• POST /api/auth/social-login-check - 기존 회원 확인
• POST /api/auth/profile-create - 신규 회원 프로필 생성
• POST /api/auth/email-signup - 기존 signup 이름 변경

플로우:
1. iOS → 소셜 토큰으로 체크 요청
2. 기존 회원이면 바로 JWT 반환, 신규면 이메일만 반환
3. 신규 회원은 닉네임/사진 입력 후 프로필 생성으로 회원가입 완료